### PR TITLE
Import package javax.inject instead of requiring bundle javax.inject

### DIFF
--- a/plugins/org.eclipse.php.composer.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.php.composer.core/META-INF/MANIFEST.MF
@@ -16,8 +16,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.commons.logging,
  org.eclipse.php.composer.api,
  org.eclipse.wst.validation,
- org.eclipse.e4.core.di.annotations,
- javax.inject
+ org.eclipse.e4.core.di.annotations
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: 
@@ -38,5 +37,6 @@ Export-Package:
  org.eclipse.php.composer.core.visitor,
  org.eclipse.php.composer.internal.core.resources,
  org.eclipse.php.composer.internal.core.util
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"
 
 

--- a/plugins/org.eclipse.php.composer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.php.composer.ui/META-INF/MANIFEST.MF
@@ -35,7 +35,6 @@ Require-Bundle: org.eclipse.ui.forms,
  org.eclipse.tm.terminal.view.ui,
  org.eclipse.tm.terminal.connector.process,
  org.eclipse.tm.terminal.control,
- javax.inject,
  org.eclipse.ui.genericeditor,
  org.eclipse.ui.editors
 Bundle-RequiredExecutionEnvironment: JavaSE-17
@@ -62,4 +61,5 @@ Export-Package:
  org.eclipse.php.composer.ui.wizard.importer,
  org.eclipse.php.composer.ui.wizard.project,
  org.eclipse.php.composer.ui.wizard.project.template
+Import-Package: javax.inject;version="[1.0.0,2.0.0)"
 Bundle-ClassPath: .


### PR DESCRIPTION
This allows the OSGi runtime and the Eclipse SimRel to use other providers of the 'javax.inject' package. In this case for example the jakarta-bundles providing it too.

This is done in the context of https://github.com/eclipse-simrel/simrel.build/pull/49